### PR TITLE
Update functions.php

### DIFF
--- a/globals/functions.php
+++ b/globals/functions.php
@@ -637,9 +637,6 @@ function include_map($element_id) {
 
 	include_map_dependencies();;
 
-	// Include needed javascript
-	include_js_language_tokens();
-	
 	$main->html->head->add_extra(
 			"<script type=\"text/javascript\">
 			$(function() {


### PR DESCRIPTION
fixes lang = { } appearing twice in the header anytime a map is displayed. as it gets called in include_map_dependencies()

only change is removal of line 640,641 (think the rest is formatting)
-   // Include needed javascript
-   include_js_language_tokens();
