### PR TITLE
overwrite files notices

### DIFF
--- a/globals/language/dutch.php
+++ b/globals/language/dutch.php
@@ -17,6 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*
+*
+*  DONT EDIT THIS FILE FOR YOUR COMMUNITY PAGE!!
+*  See config/language/LANGUAGE_overwrite.php as per the github WIKI.
+*
+*/
+
 setlocale(LC_ALL, 'en_US.utf8', 'Dutch');
 
 $lang = array(

--- a/globals/language/dutch.php
+++ b/globals/language/dutch.php
@@ -17,12 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/*
+/*****
 *
 *  DONT EDIT THIS FILE FOR YOUR COMMUNITY PAGE!!
 *  See config/language/LANGUAGE_overwrite.php as per the github WIKI.
 *
-*/
+*****/
 
 setlocale(LC_ALL, 'en_US.utf8', 'Dutch');
 

--- a/globals/language/english.php
+++ b/globals/language/english.php
@@ -17,12 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-/*
+/*****
 *
 *  DONT EDIT THIS FILE FOR YOUR COMMUNITY PAGE!!
 *  See config/language/LANGUAGE_overwrite.php as per the github WIKI.
 *
-*/
+*****/
 
 setlocale(LC_ALL, 'en_US.utf8', 'english');
 

--- a/globals/language/english.php
+++ b/globals/language/english.php
@@ -16,6 +16,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+ 
+/*
+*
+*  DONT EDIT THIS FILE FOR YOUR COMMUNITY PAGE!!
+*  See config/language/LANGUAGE_overwrite.php as per the github WIKI.
+*
+*/
 
 setlocale(LC_ALL, 'en_US.utf8', 'english');
 

--- a/globals/language/greek.php
+++ b/globals/language/greek.php
@@ -17,6 +17,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*****
+*
+*  DONT EDIT THIS FILE FOR YOUR COMMUNITY PAGE!!
+*  See config/language/LANGUAGE_overwrite.php as per the github WIKI.
+*
+*****/
+
 /* el_GR.utf8 for GNU/Linux - ell for Windows */
 setlocale(LC_ALL, 'el_GR.utf8', 'ell');
 

--- a/templates/basic/images/main_logo.README
+++ b/templates/basic/images/main_logo.README
@@ -1,0 +1,6 @@
+/*****
+*
+*  DONT EDIT THE "main_logo.png" FOR YOUR COMMUNITY PAGE!!
+*  See config/mylogo.png as per the github WIKI for your custom logo
+*
+*****/

--- a/templates/basic/includes/pages/startup/startup.tpl
+++ b/templates/basic/includes/pages/startup/startup.tpl
@@ -15,6 +15,14 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *}
+ 
+ {*
+ *
+ *  DONT EDIT THIS FILE FOR YOUR COMMUNITY PAGE!!
+ *  See config/startup.html as per the github WIKI.
+ *
+ *}
+ 
 {include file=generic/page-title.tpl title="`$community_name`"}
 <div class="page-content start-page">
 {if $startup_html != ''}


### PR DESCRIPTION
notices to not edit source files as there are already existing methods for configuring these.

By not editing the source files, it allows administrators easy upgrade paths when upgrading to newer versions of WiND.
