### PR TITLE
Link Profiler fix for North and South of the equator

### DIFF
--- a/globals/classes/srtm.php
+++ b/globals/classes/srtm.php
@@ -144,40 +144,27 @@ function __construct($data_path='') {
                                      Line:$line, pixel:$pixel, offset:$offset<br />\n";
                 }
 
-                if ($lat_dir == "S") { //South of the equator Read
-                        fseek($file, $offset);
-                        //reverse string - file read (handle, length)
-                        $h1 = srtm::bytes2int(strrev(fread($file, 2)));
-                        if ($h1 == -32768) { //Max depth, make 0
-                                $h1 = 0;
-                        }
-                        fclose ($file);
-                        return $h1;
-                } else { //North of the equator Read (un-modified WiND Version)
-                        fseek($file, $offset);
-                        $h1 = srtm::bytes2int(strrev(fread($file, 2)));
-                        $h2 = srtm::bytes2int(strrev(fread($file, 2)));
-                        fseek($file, $offset-2402);
-                        $h3 = srtm::bytes2int(strrev(fread($file, 2)));
-                        $h4 = srtm::bytes2int(strrev(fread($file, 2)));
-                        fclose($file);
+                fseek($file, $offset);
+                //reverse string - file read (handle, length)
+                $h1 = $h2 = srtm::bytes2int(strrev(fread($file, 2)));
+                fseek($file, $offset-2402);
+                $h3 = $h4 = srtm::bytes2int(strrev(fread($file, 2)));
+                fclose($file);
 
-                        $m = max($h1, $h2, $h3, $h4);
-                        for($i=1;$i<=4;$i++) {
-                                $c = 'h'.$i;
-                                if ($$c == -32768)
-                                        $$c = $m;
-                        }
+                $m = max($h1, $h2, $h3, $h4);
+                for($i=1;$i<=4;$i++) {
+                        $c = 'h'.$i;
+                        if ($$c == -32768)
+                                $$c = $m;
+                }
 
-                        $fx = ($lon - ((integer)($lon * 1200) / 1200)) * 1200;
-                        $fy = ($lat - ((integer)($lat * 1200) / 1200)) * 1200;
+                $fx = ($lon - ((integer)($lon * 1200) / 1200)) * 1200;
+                $fy = ($lat - ((integer)($lat * 1200) / 1200)) * 1200;
 
-                        // normalizing data
-                        $elevation = ($h1 * (1 - $fx) + $h2 * $fx) * (1 - $fy) + ($h3 * (1 - $fx) + $h4 * $fx) * $fy;
-                        if ($round) $elevation = round($elevation);
-                        return $elevation;
-
-                } //End else
+                // normalizing data (smooths landscape from jutting out)
+                $elevation = ($h1 * (1 - $fx) + $h2 * $fx) * (1 - $fy) + ($h3 * (1 - $fx) + $h4 * $fx) * $fy;
+                if ($round) $elevation = round($elevation);
+                return $elevation;
 
         } //End get_elevation
 

--- a/globals/classes/srtm.php
+++ b/globals/classes/srtm.php
@@ -74,38 +74,120 @@ function __construct($data_path='') {
                 $y = $lat;
                 $x = $lon;
 
-                //whole number - full number * lines (1201)
-                // * (
-                $line = (integer)(( (integer)$lat - $lat )* 1201);
-                $pixel = round(($lon - (integer)$lon ) * 1201);
+                /*
+                   Exracting data from NASA .hgt files?
+                   Here is a description from www2.jpl.nasa.gov/srtm/faq.html:
 
+                 * The SRTM data files have names like "N34W119.hgt". What do the letters and numbers refer to, and what is ".hgt" format?
+                 *
+                 * Each data file covers a one-degree-of-latitude by one-degree-of-longitude block of Earth's surface.
+                 * The first seven characters indicate the southwest corner of the block, with N, S, E, and W referring
+                 * to north, south, east, and west. Thus, the "N34W119.hgt" file covers
+                 * latitudes 34 to 35 North and
+                 * longitudes 118-119 West
+                 * (this file includes downtown Los Angeles, California).
+                 * The filename extension ".hgt" simply stands for the word "height", meaning elevation.
+                 * It is NOT a format type. These files are in "raw" format (no headers and not compressed),
+                 * 16-bit signed integers, elevation measured in meters above sea level, in a
+                 * "geographic" (latitude and longitude array) projection, with data voids indicated by -32768.
+                 *
+                 * International 3-arc-second files have 1201 columns and 1201 rows of data, with a total filesize
+                 * of 2,884,802 bytes ( = 1201 x 1201 x 2).
+                 *
+                 * United States 1-arc-second files have 3601 columns and 3601 rows of data, with a total filesize
+                 * of 25,934,402 bytes ( = 3601 x 3601 x 2).
+                 *
+                 * For more information read the text file "SRTM_Topo.txt" at http://dds.cr.usgs.gov/srtm/version1/Documentation/SRTM_Topo.txt
+
+                 *** S-WiND ***
+                 Due to the nature of HGT files, we must read the HGT differently depending if the location is
+                 North or South of the equator.
+                 - We read them as 2 byte binary
+                 - check against http://www.heywhatsthat.com/profiler.html
+
+                 A HGT file records elevations within a square.
+                 Data is stored from the upper left corner.     -->     +----+
+                 							|    |
+                 							|    |
+                 The File is named from its lower left corner   -->     +----+
+
+                 *** Not implimented until required ***
+                 USA has 1-arc-second files (its like HD for HGT files)
+                 * These require 3601 rows + colums,
+                 * so if it is ever needed, the calcs below need adjusting and testing for that.
+
+                 jammin - 31/1/2016
+                 */
+
+                if ($lat_dir == "S") { //South of the equator offset
+                	//Round ensures a whole number for pixel
+                        $line = (integer)(( (integer)$lat - $lat ) * 1201) * 1201;
+                        $pixel = round(($lon - (integer)$lon ) * 1201);
+
+                        $offset = ($line + $pixel)*2;
+                } else {  //North of the equator offset 
+                	/* (un-modified WiND version)
+                        $offset = ( (integer)(($x - (integer)$x + $lon_adj) * 1200)
+                                        * 2 + (1200 - (integer)(($y - (integer)$y + $lat_adj) * 1200))
+                                        * 2402 );
+                        */
+                        $line = (1200 - (integer)(($y - (integer)$y + $lat_adj) * 1200));
+                        $pixel = (integer)(($x - (integer)$x + $lon_adj) * 1200) * 2;
+                        $offset = $pixel + $line * 2402;
+                }
+                
                 //Debug
-                if (isset($_SESSION['userdata']['id']) && $_SESSION['userdata']['id']=="-1") {
-                        //echo "filename:$filename, lat:$lat, lon:$lon\n";
-                        //echo "Line:$line, pixel:$pixel, iLine:$iLine,
-			//offset $offset_no_adj <br />\n";
+                if (isset($main->userdata->privileges['admin']) && $main->userdata->privileges['admin'] === TRUE && $vars['debug']['enabled'] == TRUE) {
+                        echo "DEBUG - SRTM.php - filename:$filename,
+                             lat:$lat, lat_dir:$lat_dir
+                                     lon:$lon, lon_dir:$lon_dir
+                                     Line:$line, pixel:$pixel, offset:$offset<br />\n";
                 }
-                //file naming is from lower left corner.
-                //data is stored within the file from the upper left corner.
-                $offset = (($line*1201) + $pixel)*2;
 
-                fseek($file, $offset);
-                //reverse string - file read (handle, length)
-                $h1 = bytes2int(strrev(fread($file, 2)));
-                if ($h1 == -32768) {
-                        $h1 = 0;
-                }
-                fclose ($file);
-                return $h1;
+                if ($lat_dir == "S") { //South of the equator Read
+                        fseek($file, $offset);
+                        //reverse string - file read (handle, length)
+                        $h1 = srtm::bytes2int(strrev(fread($file, 2)));
+                        if ($h1 == -32768) { //Max depth, make 0
+                                $h1 = 0;
+                        }
+                        fclose ($file);
+                        return $h1;
+                } else { //North of the equator Read (un-modified WiND Version)
+                        fseek($file, $offset);
+                        $h1 = srtm::bytes2int(strrev(fread($file, 2)));
+                        $h2 = srtm::bytes2int(strrev(fread($file, 2)));
+                        fseek($file, $offset-2402);
+                        $h3 = srtm::bytes2int(strrev(fread($file, 2)));
+                        $h4 = srtm::bytes2int(strrev(fread($file, 2)));
+                        fclose($file);
+
+                        $m = max($h1, $h2, $h3, $h4);
+                        for($i=1;$i<=4;$i++) {
+                                $c = 'h'.$i;
+                                if ($$c == -32768)
+                                        $$c = $m;
+                        }
+
+                        $fx = ($lon - ((integer)($lon * 1200) / 1200)) * 1200;
+                        $fy = ($lat - ((integer)($lat * 1200) / 1200)) * 1200;
+
+                        // normalizing data
+                        $elevation = ($h1 * (1 - $fx) + $h2 * $fx) * (1 - $fy) + ($h3 * (1 - $fx) + $h4 * $fx) * $fy;
+                        if ($round) $elevation = round($elevation);
+                        return $elevation;
+
+                } //End else
+
+        } //End get_elevation
+
+        function bytes2int($val) {
+                $t = unpack("s", $val);
+                $ret = $t[1];
+                return $ret;
         }
 
-}
-
-function bytes2int($val) {
-        $t = unpack("s", $val);
-        $ret = $t[1];
-        return $ret;
-}
+} //end class
 
 
 ?>


### PR DESCRIPTION
Fix for issue #6 

Tested South and North links.

The North is just raw input from WiND

Here is output of a North of the equator link working in S-WiND and compared against  http://www.heywhatsthat.com/profiler.html
![image](https://cloud.githubusercontent.com/assets/6802951/12743403/9c2473fc-c9c8-11e5-8034-749620a8546e.png)
